### PR TITLE
expose store_blocks_2020

### DIFF
--- a/geosnap/_data.py
+++ b/geosnap/_data.py
@@ -156,7 +156,8 @@ class DataStore:
             by default "gcs"
         accept_eula : bool, optional
             pass True to accept the terms of the SEDA End User License Agreeement.
-            The data and its agreement can be viewed at <https://purl.stanford.edu/db586ns4974>
+            The data and its agreement can be viewed at
+            <https://exhibits.stanford.edu/data/catalog/db586ns4974>
         """
         eula = """
 DATA USE AGREEMENT:
@@ -379,7 +380,7 @@ Subject to your compliance with the terms and conditions set forth in this Agree
         msg = (
             "Unable to locate local census 2020 block data. Streaming instead.\n"
             "If you plan to use census data repeatedly you can store it locally "
-            "with the io.store_blocks_2010 function for better performance"
+            "with the io.store_blocks_2020 function for better performance"
         )
         if isinstance(states, (str, int)):
             states = [states]

--- a/geosnap/io/__init__.py
+++ b/geosnap/io/__init__.py
@@ -7,6 +7,7 @@ from .storage import (
     store_acs,
     store_blocks_2000,
     store_blocks_2010,
+    store_blocks_2020,
     store_census,
     store_ejscreen,
     store_ltdb,
@@ -16,8 +17,4 @@ from .storage import (
 )
 from .util import (
     adjust_inflation,
-    convert_census_gdb,
-    get_census_gdb,
-    get_lehd,
-    process_acs,
 )

--- a/geosnap/tests/test_add_data.py
+++ b/geosnap/tests/test_add_data.py
@@ -40,23 +40,23 @@ def test_store_ncdb():
     assert datasets.ncdb().shape == (328633, 76)
 
 
-def test_get_lehd_v7():
+def test_get_lodes_wac_v7():
+    wac = io.get_lodes(datasets, state_fips=['11'], years=[2015], version=7)
+    assert wac.shape == (6507, 57)
 
-    wac = io.get_lehd(version=7)
-    rac = io.get_lehd("rac", version=7)
+def test_get_lodes_rac_v7():
+    rac = io.get_lodes(datasets, dataset="rac", state_fips=['11'], years=[2015], version=7)
+    assert rac.shape == (6507, 47)
 
-    assert wac.shape == (3074, 52)
-    assert rac.shape == (4382, 42)
+def test_get_lodes_wac_v8():
+    wac = io.get_lodes(datasets, state_fips=['11'], years=[2015], version=7)
+    assert wac.shape == (6507, 57)
 
-def test_get_lehd_v8():
-
-    wac = io.get_lehd(version=8)
-    rac = io.get_lehd("rac", version=8)
-
-    assert wac.shape == (3269, 52)
-    assert rac.shape == (4553, 42)
-
+def test_get_lodes_rac_v8():
+    rac = io.get_lodes(datasets, dataset="rac", state_fips=['11'], years=[2015], version=8)
+    assert rac.shape == (6012, 49)
 
 
 def test_store_acs():
     io.store_acs(2012)
+    assert os.path.exists(PurePath(datasets.show_data_dir(), "acs", "acs_2012_tract.parquet"))


### PR DESCRIPTION
the function was missing from the init... Also updates a URL in the seda documentation and updates the tests for block storage

