### PR TITLE
isochrone parallel tests

### DIFF
--- a/geosnap/tests/test_isochrones.py
+++ b/geosnap/tests/test_isochrones.py
@@ -21,14 +21,14 @@ def get_data():
 
     return example_origin, sd_network
 
-
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="skipping test on windows because of dtype issue")
 @pytest.mark.xdist_group(name="group1")
 def test_isos_from_ids():
     example_origin, sd_network = get_data()
     iso = isochrones_from_id(example_origin, sd_network, threshold=1600)
     assert_almost_equal(iso.area.round(6).astype(float).tolist()[0], 0.000128)
 
-
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="skipping test on windows because of dtype issue")
 @pytest.mark.xdist_group(name="group1")
 def test_isos_from_gdf():
     example_origin, sd_network = get_data()

--- a/geosnap/tests/test_isochrones.py
+++ b/geosnap/tests/test_isochrones.py
@@ -7,6 +7,7 @@ import pandana as pdna
 import geopandas as gpd
 import os
 import pytest
+import sys
 from numpy.testing import assert_almost_equal
 
 
@@ -21,14 +22,22 @@ def get_data():
 
     return example_origin, sd_network
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="skipping test on windows because of dtype issue")
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="skipping test on windows because of dtype issue",
+)
 @pytest.mark.xdist_group(name="group1")
 def test_isos_from_ids():
     example_origin, sd_network = get_data()
     iso = isochrones_from_id(example_origin, sd_network, threshold=1600)
     assert_almost_equal(iso.area.round(6).astype(float).tolist()[0], 0.000128)
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="skipping test on windows because of dtype issue")
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="skipping test on windows because of dtype issue",
+)
 @pytest.mark.xdist_group(name="group1")
 def test_isos_from_gdf():
     example_origin, sd_network = get_data()

--- a/geosnap/tests/test_isochrones.py
+++ b/geosnap/tests/test_isochrones.py
@@ -10,24 +10,27 @@ import geopandas as gpd
 import os
 import pytest
 
-if not os.path.exists("./41740.h5"):
-    import quilt3 as q3
+def get_data():
+    if not os.path.exists("./41740.h5"):
+        import quilt3 as q3
 
-    b = q3.Bucket("s3://spatial-ucr")
-    b.fetch("osm/metro_networks_8k/41740.h5", "./41740.h5")
+        b = q3.Bucket("s3://spatial-ucr")
+        b.fetch("osm/metro_networks_8k/41740.h5", "./41740.h5")
+    sd_network = pdna.Network.from_hdf5("41740.h5")
+    example_origin = 1985327805
+    
+    return example_origin, sd_network
 
-datasets = DataStore()
-sd_tracts = get_acs(datasets, county_fips="06073", years=[2018])
-sd_network = pdna.Network.from_hdf5("41740.h5")
-example_origin = 1985327805
 
 @pytest.mark.xdist_group(name="group1")
 def test_isos_from_ids():
+    example_origin, sd_network = get_data()
     iso = isochrones_from_id(example_origin, sd_network, threshold=1600)
     assert iso.area.round(6).tolist()[0] == 0.000128
 
 @pytest.mark.xdist_group(name="group1")
 def test_isos_from_gdf():
+    example_origin, sd_network = get_data()
     sd_network.nodes_df["geometry"] = gpd.points_from_xy(
         sd_network.nodes_df.x, sd_network.nodes_df.y
     )

--- a/geosnap/tests/test_isochrones.py
+++ b/geosnap/tests/test_isochrones.py
@@ -2,13 +2,13 @@ from geosnap.analyze import (
     isochrones_from_id,
     isochrones_from_gdf,
 )
-from geosnap.io import get_acs
-from geosnap import DataStore
 
 import pandana as pdna
 import geopandas as gpd
 import os
 import pytest
+from numpy.testing import assert_almost_equal
+
 
 def get_data():
     if not os.path.exists("./41740.h5"):
@@ -18,7 +18,7 @@ def get_data():
         b.fetch("osm/metro_networks_8k/41740.h5", "./41740.h5")
     sd_network = pdna.Network.from_hdf5("41740.h5")
     example_origin = 1985327805
-    
+
     return example_origin, sd_network
 
 
@@ -26,7 +26,8 @@ def get_data():
 def test_isos_from_ids():
     example_origin, sd_network = get_data()
     iso = isochrones_from_id(example_origin, sd_network, threshold=1600)
-    assert iso.area.round(6).tolist()[0] == 0.000128
+    assert_almost_equal(iso.area.round(6).astype(float).tolist()[0], 0.000128)
+
 
 @pytest.mark.xdist_group(name="group1")
 def test_isos_from_gdf():
@@ -43,4 +44,4 @@ def test_isos_from_gdf():
         network=sd_network,
         threshold=1600,
     )
-    assert t.area.round(8).tolist()[0] == 0.00012821
+    assert_almost_equal(t.area.astype(float).round(8).tolist()[0], 0.00012821)

--- a/geosnap/tests/test_isochrones.py
+++ b/geosnap/tests/test_isochrones.py
@@ -8,6 +8,7 @@ from geosnap import DataStore
 import pandana as pdna
 import geopandas as gpd
 import os
+import pytest
 
 if not os.path.exists("./41740.h5"):
     import quilt3 as q3
@@ -20,12 +21,12 @@ sd_tracts = get_acs(datasets, county_fips="06073", years=[2018])
 sd_network = pdna.Network.from_hdf5("41740.h5")
 example_origin = 1985327805
 
-
+@pytest.mark.xdist_group(name="group1")
 def test_isos_from_ids():
     iso = isochrones_from_id(example_origin, sd_network, threshold=1600)
     assert iso.area.round(6).tolist()[0] == 0.000128
 
-
+@pytest.mark.xdist_group(name="group1")
 def test_isos_from_gdf():
     sd_network.nodes_df["geometry"] = gpd.points_from_xy(
         sd_network.nodes_df.x, sd_network.nodes_df.y


### PR DESCRIPTION
current tests for isochrones fail because multiple processes try to open the h5 file in write mode. Trying to run those tests in sequence (via the same worker?) using a pytest-xdist mark