### PR TITLE
allow edge vertices in isochones

### DIFF
--- a/geosnap/analyze/network.py
+++ b/geosnap/analyze/network.py
@@ -248,7 +248,7 @@ def isochrones_from_gdf(
     for origin in matrix.origin.unique():
         do = matrix[matrix.origin == origin]
         dest_pts = gpd.GeoDataFrame(destinations.loc[do["destination"]])
-        if use_edges:
+        if use_edges is False:
             dest_pts = dest_pts.geometry.tolist()
         else:
             edges = network.edges_df.copy()

--- a/geosnap/io/networkio.py
+++ b/geosnap/io/networkio.py
@@ -24,9 +24,9 @@ def get_network_from_gdf(
     Parameters
     ----------
     gdf : geopandas.GeoDataFrame
-        dataframe covering the study area of interest; this should be stored in lat/long
-        (epsg 4326). Note the first step is to take the unary union of this dataframe,
-        which is expensive, so large dataframes may be time-consuming
+        dataframe covering the study area of interest; Note the first step is to take
+        the unary union of this dataframe, which is expensive, so large dataframes may
+        be time-consuming. The network will inherit the CRS from this dataframe
     network_type : str, {"all_private", "all", "bike", "drive", "drive_service", "walk"}
         the type of network to collect from OSM (passed to `osmnx.graph_from_polygon`)
         by default "walk"
@@ -34,11 +34,12 @@ def get_network_from_gdf(
         Whether to treat the pandana.Network as directed or undirected. For a directed network,
         use `twoway=False` (which is the default). For an undirected network (e.g. a
         walk network) where travel can flow in both directions, the network is more
-        efficient when twoway=True. This has implications for drive networks or multimodal
-        networks where impedance is different depending on travel direction.
+        efficient when twoway=True but forces the impedance to be equal in both
+        directions. This has implications for auto or multimodal
+        networks where impedance is generally different depending on travel direction.
     add_travel_times : bool, default=False
         whether to use posted travel times from OSM as the impedance measure (rather
-        than network-distance). Speeds are based on max drive speeds, see
+        than network-distance). Speeds are based on max posted drive speeds, see
         <https://osmnx.readthedocs.io/en/stable/internals-reference.html#osmnx-speed-module>
         for more information.
     default_speeds : dict, optional
@@ -50,7 +51,9 @@ def get_network_from_gdf(
     -------
     pandana.Network
         a pandana.Network object with node coordinates stored in the same system as the
-        input geodataframe
+        input geodataframe. If add_travel_times is True, the network impedance
+        is travel time measured in seconds (assuming automobile travel speeds); else 
+        the impedance is travel distance measured in meters
 
     Raises
     ------
@@ -92,7 +95,7 @@ def get_network_from_gdf(
         e = e.to_crs(output_crs)
     e = e.reset_index()
 
-    net= pdna.Network(
+    net = pdna.Network(
         edge_from=e["u"],
         edge_to=e["v"],
         edge_weights=e[[impedance]],
@@ -133,7 +136,7 @@ def project_network(network, output_crs=None, input_crs=4326):
     #  take original x,y coordinates and convert into geopandas.Series, then reproject
     nodes = _reproject_osm_nodes(network.nodes_df, input_crs, output_crs)
     edges = network.edges_df.copy()
-    if 'geometry' in edges:
+    if "geometry" in edges.columns:
         edges = edges.to_crs(output_crs)
 
     #  reinstantiate the network (needs to rebuild the tree)
@@ -141,8 +144,8 @@ def project_network(network, output_crs=None, input_crs=4326):
         node_x=nodes["x"],
         node_y=nodes["y"],
         edge_from=edges["from"],
-        edge_to=network.edges["to"],
-        edge_weights=network.edges[network.impedance_names],
+        edge_to=edges["to"],
+        edge_weights=edges[[network.impedance_names[0]]],
         twoway=network._twoway,
     )
     return net

--- a/geosnap/tests/test_isochrones.py
+++ b/geosnap/tests/test_isochrones.py
@@ -85,6 +85,10 @@ def test_network_constructor():
     # this will grow depending on the size of the OSM network when tested...
     assert walk_net.edges_df.shape[0] > 6000
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="skipping test on windows because of dtype issue",
+)
 def test_isos_with_edges():
     tracts = get_acs(DataStore(), county_fips='48301', level='tract', years=2015)
     walk_net = get_network_from_gdf(tracts)
@@ -99,7 +103,7 @@ def test_isos_with_edges():
     print(alpha.area.round(8))
     # this will grow depending on the size of the OSM network when tested...
     assert alpha.area.round(8).iloc[0] == 0.00026001
-    
+
 def test_project_network():   
     tracts = get_acs(DataStore(), county_fips='48301', level='tract', years=2015)
     walk_net = get_network_from_gdf(tracts)


### PR DESCRIPTION
ok, this is really neat. When you build a pandana network using a query from OSMnx, you get the geometries back for free. In that case, we can explode the road geometries to make the isochrone more accurate by filling in gaps where there are roads but no intersections. Original implementation:

<img width="551" alt="Screenshot 2024-03-04 at 4 27 21 PM" src="https://github.com/oturns/geosnap/assets/4213368/70604e27-3e18-4f9c-8b0b-923665ab35a1">

versus the new option to `use_edges` when available:

<img width="552" alt="Screenshot 2024-03-04 at 4 23 04 PM" src="https://github.com/oturns/geosnap/assets/4213368/55511f0c-1249-4958-b0ca-41db6a898b43">
